### PR TITLE
Add Prettier configuration to avoid quote changes on save

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
       "react-app/jest"
     ]
   },
+  "prettier": {
+    "singleQuote": true
+  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
### What's the problem?
Hello! So for folks who use the [VSCode Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode), a lot of files will be reformatted on save. [By default](https://prettier.io/docs/en/options.html#quotes), this means all single quotes are turned into double quotes, so a simple change suddenly results in an avalanche of updates.

See below for an example of just changing the margin value and stomping {cmd|ctrl}+s in `app.css`.
![Screenshot from 2021-11-09 18-50-26](https://user-images.githubusercontent.com/5721314/140986223-a7428354-97a8-4d53-ba0a-59edc968c3c5.png)


### Whatctha doing doing about it?
You can tell Prettier to embrace the single quote lifestyle in the usual volley of ways. A custom configuration file, a JSON blob somewhere, or adding to `package.json`. This means saving now will not cause unintended additional formatting changes for Prettier users.

The additional Prettier configuration will not affect non-Prettier users.

### OK cool but you have to tell me the drawbacks
While Prettier has been pretty (heh) popular at all the gigs I've taken for the last few years, it is an extra bit of configuration, small, but also now it's something else to maintain as technical overhead. For example, if they change the configuration key from `singleQuote` to `quoteIsSingle` (a dumb example but it's late OK) then this will need to be updated again.

No configuration at all is a good way to let users know "hey this is your plugin and thus your problem".

Anyway! Up to you, I just thought I'd provide the option.

![austin-powers-quote-on-quote](https://user-images.githubusercontent.com/5721314/140987403-0451cf16-27c6-42b4-941a-55584f4b80a6.gif)
