### PR TITLE
Fixed "useEffect is not defined" error

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,4 @@
+import React, { useEffect } from 'react';
 import twitterLogo from './assets/twitter-logo.svg';
 import './App.css';
 


### PR DESCRIPTION
This boilerplate code doesn't actually import useEffect function for React.

This causes new developers to see an error saying "useEffect is not defined".

I added  an import statement for "useEffect" to fix this error.

By fixing this small error, developers can focus on the actual class material rather than trying to debug this simple but pesky React error.