### PR TITLE
FIX for --- When running npm start - error ERR_OSSL_EVP_UNSUPPORTED

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "web-vitals": "^1.0.1"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "react-scripts --openssl-legacy-provider start",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
I have made a PR for the issue #29 and solved it by updating package.json.

The reason I discovered is that - the current package is attempting to use an algorithm or key size which is no longer allowed by default with OpenSSL 3.0

I have provded the fix in accordance with the [release notes](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V17.md#17.0.0) for Node.js 17.